### PR TITLE
Fix Header of the Life Map on Responsive Version

### DIFF
--- a/src/components/TitleBar.js
+++ b/src/components/TitleBar.js
@@ -123,7 +123,10 @@ const styles = theme => ({
     height: '100%',
     left: '50%',
     top: 0,
-    transform: 'translateX(-50%)'
+    transform: 'translateX(-50%)',
+    [theme.breakpoints.down('xs')]: {
+      justifyContent: 'center'
+    }
   },
   titleMainAll: {
     margin: 'auto',
@@ -131,7 +134,10 @@ const styles = theme => ({
     textAlign: 'center'
   },
   barDots: {
-    height: '70%'
+    height: '70%',
+    [theme.breakpoints.down('xs')]: {
+      display: 'none'
+    }
   },
   textContainer: {
     display: 'flex',


### PR DESCRIPTION
In the current implementation, the dots occupies space in the bar that makes the title shrink, and change its position:
<img width="369" alt="Screen Shot 2019-05-21 at 10 55 36" src="https://user-images.githubusercontent.com/13141462/58107411-c5d7da00-7bb7-11e9-83bb-f92e327921ac.png">

One fix would be removing the dots from devices with screen widths less than 600px (<600px), the other fix will be making the font smaller.

Currently it look like this:
<img width="364" alt="Screen Shot 2019-05-21 at 10 56 07" src="https://user-images.githubusercontent.com/13141462/58107417-c8d2ca80-7bb7-11e9-88fe-461079db6637.png">

If we need to make the font smaller, in which font size should we work on? @stacylorraineprendeville 
