### PR TITLE
UK cut images in their platform user

### DIFF
--- a/src/screens/lifemap/StoplightQuestions.js
+++ b/src/screens/lifemap/StoplightQuestions.js
@@ -20,9 +20,9 @@ const questionsWrapperStyles = {
   },
   questionImage: {
     objectFit: 'cover',
-    height: '100%',
     width: '100%',
-    display: 'block'
+    position: 'absolute',
+    top: 0
   },
   answeredQuestion: {
     justifyContent: 'center',
@@ -66,10 +66,13 @@ const questionsWrapperStyles = {
     alignItems: 'flex-start'
   },
   imageContainer: {
-    height: 240
+    position: 'relative'
   },
   circularProgress: {
-    color: 'white'
+    color: 'white',
+    height: 240,
+    position: 'absolute',
+    top: '50%'
   }
 };
 

--- a/src/screens/lifemap/StoplightQuestions.js
+++ b/src/screens/lifemap/StoplightQuestions.js
@@ -82,7 +82,9 @@ let QuestionsWrapper = ({
   classes,
   submitQuestion,
   handleImageLoaded,
-  imageStatus
+  imageStatus,
+  setAspectRatio,
+  aspectRatio
 }) => {
   const [showIcon, setShowIcon] = useState(0);
   let sortedQuestions;
@@ -93,6 +95,17 @@ let QuestionsWrapper = ({
       return b.value - a.value;
     });
   }
+
+  const handleLoad = e => {
+    const { width, height } = e.target;
+    setAspectRatio(width / height);
+    handleImageLoaded(e);
+  };
+
+  const getPaddingBottom = a => {
+    const paddingBottom = a !== null ? 100 / a : null;
+    return { paddingBottom: `${paddingBottom}%` };
+  };
 
   return (
     <Grid container spacing={16}>
@@ -129,7 +142,10 @@ let QuestionsWrapper = ({
               >
                 <React.Fragment>
                   {imageStatus < sortedQuestions.length && (
-                    <div className={classes.imageContainer}>
+                    <div
+                      className={classes.imageContainer}
+                      style={getPaddingBottom(1)}
+                    >
                       <div className={classes.loadingContainer}>
                         {' '}
                         <CircularProgress
@@ -138,7 +154,7 @@ let QuestionsWrapper = ({
                         />
                       </div>
                       <img
-                        onLoad={handleImageLoaded}
+                        onLoad={handleLoad}
                         src={e.url}
                         alt="surveyImg"
                         style={{ display: 'none', height: 0 }}
@@ -146,7 +162,10 @@ let QuestionsWrapper = ({
                     </div>
                   )}
                   {imageStatus === sortedQuestions.length && (
-                    <div className={classes.imageContainer}>
+                    <div
+                      className={classes.imageContainer}
+                      style={getPaddingBottom(aspectRatio)}
+                    >
                       <img
                         className={classes.questionImage}
                         src={e.url}

--- a/src/screens/lifemap/StoplightQuestions.js
+++ b/src/screens/lifemap/StoplightQuestions.js
@@ -185,7 +185,8 @@ export class StoplightQuestions extends Component {
     imageStatus: null,
     question: this.props.currentSurvey.surveyStoplightQuestions[
       this.props.match.params.page
-    ]
+    ],
+    aspectRatio: null
   };
 
   handleContinue = () => {
@@ -262,7 +263,8 @@ export class StoplightQuestions extends Component {
       imageStatus: 0,
       question: this.props.currentSurvey.surveyStoplightQuestions[
         this.props.match.params.page
-      ]
+      ],
+      aspectRatio: null
     });
   }
 
@@ -270,6 +272,18 @@ export class StoplightQuestions extends Component {
     this.setState(prevState => ({
       imageStatus: prevState.imageStatus + 1
     }));
+  };
+
+  setAspectRatio = aspectRatio => {
+    this.setState(prevState => {
+      const maxAspectRatio =
+        prevState.aspectRatio > aspectRatio
+          ? prevState.aspectRatio
+          : aspectRatio;
+      return {
+        aspectRatio: maxAspectRatio
+      };
+    });
   };
 
   componentDidUpdate(prevProps) {
@@ -317,6 +331,8 @@ export class StoplightQuestions extends Component {
                 submitQuestion={e => this.submitQuestion(e)}
                 handleImageLoaded={this.handleImageLoaded}
                 imageStatus={this.state.imageStatus}
+                setAspectRatio={this.setAspectRatio}
+                aspectRatio={this.state.aspectRatio}
               />
             ) : (
               <QuestionsWrapper
@@ -324,6 +340,8 @@ export class StoplightQuestions extends Component {
                 submitQuestion={e => this.submitQuestion(e)}
                 handleImageLoaded={this.handleImageLoaded}
                 imageStatus={this.state.imageStatus}
+                setAspectRatio={this.setAspectRatio}
+                aspectRatio={this.state.aspectRatio}
               />
             )}
           </div>


### PR DESCRIPTION
#430 

So the problem here is that each survey has different aspect ratios on their images, some could be 1:1 as UK, some 4:3, or some may not have a standard aspect ratio at all.

At the time we were using a fixed height for the image's container, this approach was the responsible of this bug, causing that on some surveys, the images got cut. A solution would be making the aspect ratio of the image container to 1:1, but this will be prone to errors as some images could have a larger AR, meaning less height of the images, contrasted with the larger height of the container, would cause white space below the image. So we don't want anything fixed.

The solution i'm presenting in this PR is that for each screen, the larger aspect ratio of all three images, will be the aspect ratio for that screen, so if we have the following AR in one screen: 1:1, 4:3 and 1:1, 4:3 will be the aspect ratio selected for all three images of that screen, cutting the 1:1 image that has more height, but in my opinion is more aesthetically appealing than having white space below images.

In the other hand, if all three images have the same 1:1 AR, as UK, that AR will be used.