### PR TITLE
Combo Box not showing

### DIFF
--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -209,7 +209,6 @@ const styles = theme => ({
   titleBar: {
     paddingTop: theme.spacing(8),
     position: 'relative',
-    overflow: 'hidden',
     marginBottom: theme.spacing(5)
   },
   titleBalls: {

--- a/src/components/DashboardFilters.js
+++ b/src/components/DashboardFilters.js
@@ -11,7 +11,8 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     width: '100%',
     padding: `${theme.spacing(8)}px 0`,
-    paddingBottom: 0
+    paddingBottom: 0,
+    zIndex: 2
   }
 }));
 

--- a/src/components/DashboardFilters.js
+++ b/src/components/DashboardFilters.js
@@ -11,8 +11,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     width: '100%',
     padding: `${theme.spacing(8)}px 0`,
-    paddingBottom: 0,
-    zIndex: 2
+    paddingBottom: 0
   }
 }));
 


### PR DESCRIPTION
The title bar has a `overflow: hidden` property to hide the balls that also was hiding the menu