### PR TITLE
People Count Bug Fix

### DIFF
--- a/src/components/FamiliesOverviewBlock.js
+++ b/src/components/FamiliesOverviewBlock.js
@@ -73,6 +73,8 @@ const FamiliesOverviewBlock = ({
     ? familiesOverview.familiesCount
     : familiesCount;
 
+  const people = familiesOverview ? familiesOverview.peopleCount : peopleCount;
+
   return (
     <div
       className={classes.mainContainer}
@@ -104,9 +106,7 @@ const FamiliesOverviewBlock = ({
       </div>
       <Typography className={classes.peopleCountStyle} variant="h6">{`${t(
         'views.familiesOverviewBlock.including'
-      )} ${peopleCount || familiesOverview.peopleCount} ${t(
-        'views.familiesOverviewBlock.people'
-      )}`}</Typography>
+      )} ${people} ${t('views.familiesOverviewBlock.people')}`}</Typography>
       {/* <Typography
         className={classes.menWomenCountStyle}
         variant="h6"


### PR DESCRIPTION
Javascript takes a 0 value as a falsy value in the statement `peopleCount || familiesOverview.peopleCount` so we now verify if the object exists and then we rely on peopleCount, that has a defaultProp, so it won't be undefined.