### PR TITLE
Use reducers instead of isolated state for each component

### DIFF
--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -62,6 +62,7 @@ const reducer = (state, action) => {
 const Dashboard = ({ classes, user, t }) => {
   const [state, dispatch] = useReducer(reducer, {});
   const [loading, dispatchLoading] = useReducer(reducer, initialLoading);
+  const [loadingFeed, setLoadingFeed] = useState(true);
   const [selectedOrganizations, setSelectedOrganizations] = useState([]);
   const [selectedHub, setSelectedHub] = useState(null);
   const [fromDate, setFromDate] = useState(null);
@@ -78,7 +79,7 @@ const Dashboard = ({ classes, user, t }) => {
         const { feed } = getData(data);
         dispatch({ type: ACTIVITY_FEED, payload: feed });
       })
-      .finally(() => dispatchLoading({ type: ACTIVITY_FEED, payload: false }));
+      .finally(() => setLoadingFeed(false));
   }, [user]);
 
   useEffect(() => {
@@ -186,8 +187,8 @@ const Dashboard = ({ classes, user, t }) => {
               {t('views.dashboard.latestActivity')}
             </Typography>
             <Box mt={3} />
-            {loading.activityFeed && <LoadingContainer />}
-            {!loading.activityFeed && (
+            {loadingFeed && <LoadingContainer />}
+            {!loadingFeed && (
               <ActivityFeed
                 data={state.activityFeed}
                 width="100%"

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -20,7 +20,7 @@ import {
   ECONOMICS,
   CHART,
   LOADING,
-  START_LOADING
+  BEGIN_LOADING
 } from '../utils/types';
 import ballstoit from '../assets/ballstoit.png';
 import withLayout from '../components/withLayout';
@@ -48,7 +48,7 @@ const initialLoading = Object.fromEntries(
 
 const reducer = (state, action) => {
   switch (action.type) {
-    case START_LOADING:
+    case BEGIN_LOADING:
       return {
         ...state,
         ...initialLoading
@@ -82,7 +82,7 @@ const Dashboard = ({ classes, user, t }) => {
   }, [user]);
 
   useEffect(() => {
-    dispatchLoading({ type: START_LOADING });
+    dispatchLoading({ type: BEGIN_LOADING });
 
     const sanitizedOrganizations = selectedOrganizations.map(
       ({ value }) => value

--- a/src/utils/dashboard-state.js
+++ b/src/utils/dashboard-state.js
@@ -1,0 +1,61 @@
+import { useReducer } from 'react';
+import { camelCase } from 'lodash';
+import { SET_STATE, SET_LOADING, BEGIN_LOADING, LOADING } from './types';
+
+export const setState = payload => ({
+  type: SET_STATE,
+  payload
+});
+
+export const setLoading = payload => ({
+  type: SET_LOADING,
+  payload
+});
+
+export const beginLoading = () => ({
+  type: BEGIN_LOADING
+});
+
+// Camel case LOADING object and set to true
+export const initialLoading = Object.fromEntries(
+  LOADING.map(key => [camelCase(key), true])
+);
+
+export const dashboard = (state, action) => {
+  switch (action.type) {
+    case SET_STATE:
+      // Camel case the type and assign the payload
+      return { ...state, [camelCase(action.payload.key)]: action.payload.data };
+    case SET_LOADING:
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          [camelCase(action.payload.key)]: action.payload.loading
+        }
+      };
+    case BEGIN_LOADING:
+      return {
+        ...state,
+        loading: initialLoading
+      };
+    default:
+      return state;
+  }
+};
+
+const bindActionCreators = (actions, dispatch) => {
+  if (Array.isArray(actions)) {
+    return actions.map(a => payload => dispatch(a(payload)));
+  }
+  return payload => dispatch(actions(payload));
+};
+
+export const useDashboard = () => {
+  const [state, dispatch] = useReducer(dashboard, { loading: initialLoading });
+
+  return [
+    state,
+    ...bindActionCreators([setState, setLoading, beginLoading], dispatch)
+  ];
+};

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -14,7 +14,6 @@ export const BEGIN_LOADING = 'BEGIN_LOADING';
 export const LOADING = {
   OVERVIEW,
   ECONOMICS,
-  ACTIVITY_FEED,
   CHART,
   DIMENSIONS
 };

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -2,21 +2,18 @@
 const INDICATORS_TYPES = ['pie', 'bar'];
 const [PIE, BAR] = INDICATORS_TYPES;
 
-// Dashboard types
+// Dashboard
+export const SET_STATE = 'SET_STATE';
+export const SET_LOADING = 'SET_LOADING';
+export const BEGIN_LOADING = 'BEGIN_LOADING';
 export const ACTIVITY_FEED = 'ACTIVITY_FEED';
 export const OVERVIEW = 'OVERVIEW';
 export const INDICATORS = 'INDICATORS';
 export const DIMENSIONS = 'DIMENSIONS';
 export const ECONOMICS = 'ECONOMICS';
 export const CHART = 'CHART';
-export const BEGIN_LOADING = 'BEGIN_LOADING';
 
-export const LOADING = {
-  OVERVIEW,
-  ECONOMICS,
-  CHART,
-  DIMENSIONS
-};
+export const LOADING = [OVERVIEW, ECONOMICS, CHART, DIMENSIONS];
 
 export default INDICATORS_TYPES;
 export { PIE, BAR };

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -1,5 +1,23 @@
+// Indicators Tyepes
 const INDICATORS_TYPES = ['pie', 'bar'];
 const [PIE, BAR] = INDICATORS_TYPES;
+
+// Dashboard types
+export const ACTIVITY_FEED = 'ACTIVITY_FEED';
+export const OVERVIEW = 'OVERVIEW';
+export const INDICATORS = 'INDICATORS';
+export const DIMENSIONS = 'DIMENSIONS';
+export const ECONOMICS = 'ECONOMICS';
+export const CHART = 'CHART';
+export const START_LOADING = 'START_LOADING';
+
+export const LOADING = {
+  OVERVIEW,
+  ECONOMICS,
+  ACTIVITY_FEED,
+  CHART,
+  DIMENSIONS
+};
 
 export default INDICATORS_TYPES;
 export { PIE, BAR };

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -9,7 +9,7 @@ export const INDICATORS = 'INDICATORS';
 export const DIMENSIONS = 'DIMENSIONS';
 export const ECONOMICS = 'ECONOMICS';
 export const CHART = 'CHART';
-export const START_LOADING = 'START_LOADING';
+export const BEGIN_LOADING = 'BEGIN_LOADING';
 
 export const LOADING = {
   OVERVIEW,


### PR DESCRIPTION
The dashboard component has too many isolated states for each component and they were managed in a ad-hoc way [1], to untangle the component a bit i opted to useReducer for component's async data and their loading state.

What do you think @javierpf?

WIP: 
- [x] ActityFeed need its own state since it won't re-fetch when using the filter, ergo we need to isolate it
- [x] See other options for the API

[1]: https://reactjs.org/docs/hooks-custom.html#useyourimagination

**Edit:** I think the API is okay