### PR TITLE
Add  dimension argument for indicators filter

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1224,7 +1224,7 @@ export const getDimensionsByUser = (user, lang) =>
   });
 
 // get a list of indicators available to the authorized used
-export const getIndicatorsByUser = (user, lang) =>
+export const getIndicatorsByUser = (user, dimension, lang) =>
   axios({
     method: 'post',
     url: `${url[user.env]}/graphql`,
@@ -1233,7 +1233,11 @@ export const getIndicatorsByUser = (user, lang) =>
       'X-locale': normalizeLang(lang)
     },
     data: JSON.stringify({
-      query: 'query { getIndicators { codeName, name, surveyIndicatorId } }'
+      query:
+        'query getIndicators( $dimension: String) { getIndicators (dimension: $dimension) { codeName, name, surveyIndicatorId  } }',
+      variables: {
+        dimension: dimension
+      }
     })
   });
 

--- a/src/components/selectors/IndicatorSelector.js
+++ b/src/components/selectors/IndicatorSelector.js
@@ -31,6 +31,7 @@ const IndicatorSelector = ({
   withTitle,
   user,
   indicatorsData,
+  dimensionData,
   onChangeIndicator,
   onBlur,
   required,
@@ -50,9 +51,10 @@ const IndicatorSelector = ({
   const label = `${t('views.indicatorFilter.label')} ${required ? ' *' : ''}`;
 
   useEffect(() => {
+    let dimension = !!dimensionData ? dimensionData.label : '';
     setLoading(true);
     let lang = !!parentLang ? parentLang : language;
-    getIndicatorsByUser(user, lang)
+    getIndicatorsByUser(user, dimension, lang)
       .then(response => {
         const indicators = _.get(response, 'data.data.getIndicators', []).map(
           indicator => ({
@@ -64,7 +66,7 @@ const IndicatorSelector = ({
         setIndicatorOptions(indicators);
       })
       .finally(() => setLoading(false));
-  }, [language, parentLang]);
+  }, [language, parentLang, dimensionData]);
 
   return (
     <div className={classes.container}>

--- a/src/screens/Solutions.js
+++ b/src/screens/Solutions.js
@@ -35,7 +35,7 @@ const styles = theme => ({
   solutionImage: {
     display: 'block',
     height: 175,
-    right: -60,
+    right: -38,
     position: 'absolute',
     top: -5,
     zIndex: 0,

--- a/src/screens/Solutions.js
+++ b/src/screens/Solutions.js
@@ -281,6 +281,7 @@ const Solutions = ({ classes, user, history }) => {
             dimensionData={filterInput.dimension}
             indicatorsData={filterInput.indicators}
             solutionTypeData={filterInput.solutionType}
+            language={filterInput.lang}
             onChangeCountry={country => setFilterInput({ country })}
             onChangeDimension={dimension => setFilterInput({ dimension })}
             onChangeIndicator={indicators => setFilterInput({ indicators })}

--- a/src/screens/solutions/SolutionsFilters.js
+++ b/src/screens/solutions/SolutionsFilters.js
@@ -51,6 +51,7 @@ const SolutionFilters = ({
   dimensionData,
   indicatorsData,
   solutionTypeData,
+  language,
   onChangeCountry,
   onChangeDimension,
   onChangeIndicator,
@@ -75,6 +76,7 @@ const SolutionFilters = ({
             <CountrySelector
               withTitle={false}
               countryData={countryData}
+              parentLang={language}
               onChangeCountry={onChangeCountry}
               error={false}
               required={false}
@@ -85,6 +87,7 @@ const SolutionFilters = ({
           <DimensionSelector
             withTitle={false}
             dimensionData={dimensionData}
+            parentLang={language}
             onChangeDimension={onChangeDimension}
             error={false}
             required={false}
@@ -95,6 +98,8 @@ const SolutionFilters = ({
           <IndicatorSelector
             withTitle={false}
             indicatorsData={indicatorsData}
+            dimensionData={dimensionData}
+            parentLang={language}
             onChangeIndicator={onChangeIndicator}
             error={false}
             required={false}
@@ -117,6 +122,7 @@ const SolutionFilters = ({
             withTitle={false}
             solutionTypeData={solutionTypeData}
             onChangeSolutionType={onChangeSolutionType}
+            parentLang={language}
             isClearable={true}
             className={classes.filter}
           />

--- a/src/screens/solutions/SolutionsForm.js
+++ b/src/screens/solutions/SolutionsForm.js
@@ -455,32 +455,16 @@ const SolutionsForm = ({ user, enqueueSnackbar, closeSnackbar, history }) => {
             </div>
             <div className={classes.innerFrom}>
               {/* Show organizations switch and country selector */}
-              <Grid container spacing={1}>
-                <Grid item lg={'auto'} md={1} sm={1} xs={1}>
-                  <Switch
-                    checked={values.showOrg}
-                    onChange={() => setFieldValue('showOrg', !values.showOrg)}
-                    color="primary"
-                  />
-                </Grid>
-                <Grid
-                  item
-                  md={7}
-                  sm={7}
-                  xs={12}
-                  container
-                  justify="space-between"
-                  alignItems="center"
-                >
-                  <Grid
-                    item
-                    lg={7}
-                    md={7}
-                    sm={5}
-                    xs={5}
-                    container
-                    alignItems="center"
-                  >
+              <Grid item md={8} sm={8} xs={12} container>
+                <Grid item md={8} sm={8} xs={12} container>
+                  <Grid item lg={'auto'} md={3} sm={4} xs={4}>
+                    <Switch
+                      checked={values.showOrg}
+                      onChange={() => setFieldValue('showOrg', !values.showOrg)}
+                      color="primary"
+                    />
+                  </Grid>
+                  <Grid item lg={8} md={8} container alignItems="center">
                     {values.showOrg && (
                       <>
                         <Typography variant="subtitle1" align="center">
@@ -489,23 +473,24 @@ const SolutionsForm = ({ user, enqueueSnackbar, closeSnackbar, history }) => {
                       </>
                     )}
                   </Grid>
-                  <Grid item lg={4} md={4} sm={4} xs={4}>
-                    <SolutionLangPicker
-                      language={values.language}
-                      setLanguage={lang => {
-                        setFieldValue('language', lang);
-                      }}
-                    />
-                  </Grid>
                 </Grid>
 
                 <Grid
                   item
+                  lg={4}
                   md={4}
                   sm={4}
-                  xs={12}
-                  style={{ display: 'flex' }}
-                ></Grid>
+                  xs={4}
+                  container
+                  justify="flex-end"
+                >
+                  <SolutionLangPicker
+                    language={values.language}
+                    setLanguage={lang => {
+                      setFieldValue('language', lang);
+                    }}
+                  />
+                </Grid>
               </Grid>
               <Grid container spacing={2} style={{ minHeight: '40vh' }}>
                 <Grid item md={8} sm={8} xs={12}>

--- a/src/screens/solutions/SolutionsForm.js
+++ b/src/screens/solutions/SolutionsForm.js
@@ -550,6 +550,7 @@ const SolutionsForm = ({ user, enqueueSnackbar, closeSnackbar, history }) => {
                     <IndicatorSelector
                       withTitle={false}
                       indicatorsData={values.indicators}
+                      dimensionData={values.dimension}
                       onChangeIndicator={indicators =>
                         setFieldValue('indicators', indicators)
                       }

--- a/src/screens/solutions/SolutionsView.js
+++ b/src/screens/solutions/SolutionsView.js
@@ -282,7 +282,7 @@ const SolutionsView = ({ user, history, enqueueSnackbar, closeSnackbar }) => {
         </div>
         <div className={classes.innerFrom}>
           <Grid container>
-            <Grid item md={8} container>
+            <Grid item md={8} container justify="space-between">
               {solution.showAuthor && (
                 <Grid item lg={5} md={6} xs={8} container>
                   <GroupIcon className={classes.icon} />
@@ -293,7 +293,7 @@ const SolutionsView = ({ user, history, enqueueSnackbar, closeSnackbar }) => {
                   </Typography>
                 </Grid>
               )}
-              <Grid item lg={3} md={4} container>
+              <Grid item lg={3} md={4} container justify="flex-end">
                 <LocationOnIcon className={classes.icon} />
                 <Typography variant="h6">{country}</Typography>
               </Grid>


### PR DESCRIPTION
You'll need to review this together with the backend PR. Possible indicators options are now  filter by dimension, if you select a dimension there shouldn't be duplicated codenames however  if you don't select one there will be some apparent duplicates.