### PR TITLE
Jdelpuerto 1388 responsive survey flow

### DIFF
--- a/src/components/CheckboxWithFormik.js
+++ b/src/components/CheckboxWithFormik.js
@@ -56,7 +56,8 @@ const CheckboxWithFormik = ({
         {rawOptions.map(option => (
           <Grid
             item
-            xs={4}
+            xs={6}
+            sm={4}
             key={option.value}
             className={classes.gridCentering}
           >

--- a/src/components/LeaveModal.js
+++ b/src/components/LeaveModal.js
@@ -70,7 +70,8 @@ LeaveModal.defaultProps = {
 
 const styles = theme => ({
   leaveModal: {
-    width: 370,
+    width: '80vw',
+    maxWidth: 370,
     height: 330,
     backgroundColor: theme.palette.background.default,
     outline: 'none',
@@ -97,7 +98,11 @@ const styles = theme => ({
     justifyContent: 'space-around'
   },
   leaveModalTitle: {
-    textAlign: 'center'
+    textAlign: 'center',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 18,
+      lineHeight: 1.2
+    }
   },
   leaveModalSubtitle: {
     textAlign: 'center'

--- a/src/components/RadioWithFormik.js
+++ b/src/components/RadioWithFormik.js
@@ -48,7 +48,8 @@ const RadioWithFormik = ({
         {rawOptions.map(option => (
           <Grid
             item
-            xs={4}
+            xs={6}
+            sm={4}
             key={option.value}
             className={classes.gridCentering}
           >

--- a/src/components/SaveDraftModal.js
+++ b/src/components/SaveDraftModal.js
@@ -90,7 +90,8 @@ const SaveDraftModal = props => {
 
 const styles = theme => ({
   mainContainer: {
-    width: 470,
+    width: '80vw',
+    maxWidth: 470,
     backgroundColor: theme.palette.background.default,
     outline: 'none',
     position: 'absolute',
@@ -120,7 +121,11 @@ const styles = theme => ({
     textAlign: 'center',
     marginBottom: theme.spacing(1.5),
     color: '#6A6A6A',
-    fontSize: '24px'
+    fontSize: '24px',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 18,
+      lineHeight: 1.2
+    }
   },
   subtitle: {
     textAlign: 'center',

--- a/src/components/summary/DimensionQuestion.js
+++ b/src/components/summary/DimensionQuestion.js
@@ -51,6 +51,7 @@ const DimensionQuestion = ({
         <Grid
           item
           xs={12}
+          sm={6}
           md={3}
           lg={2}
           key={indicator.key}

--- a/src/screens/lifemap/Achievement.js
+++ b/src/screens/lifemap/Achievement.js
@@ -138,20 +138,20 @@ class Achievements extends Component {
                 )}
               </React.Fragment>
             </div>
-            <div className={classes.answeredQuestion}>
-              <i
-                style={{
-                  backgroundColor: color
-                }}
-                className={`${classes.icon} material-icons`}
-              >
-                done
-              </i>
-            </div>
             <div
               className={classes.paragraphContainer}
               style={{ backgroundColor: color }}
             >
+              <div className={classes.answeredQuestion}>
+                <i
+                  style={{
+                    backgroundColor: color
+                  }}
+                  className={`${classes.icon} material-icons`}
+                >
+                  done
+                </i>
+              </div>
               <div className={classes.editContainer}>
                 <EditIcon className={classes.editIcon} />
               </div>
@@ -261,9 +261,13 @@ const styles = theme => ({
     alignItems: 'center',
     position: 'absolute',
     top: '50%',
-    left: '50%',
+    left: '0%',
     transform: 'translate(-50%,-50%)',
-    zIndex: 1
+    zIndex: 1,
+    [theme.breakpoints.down('xs')]: {
+      top: '0%',
+      left: '50%'
+    }
   },
   pinAndPriority: {
     marginTop: '40px',
@@ -276,14 +280,21 @@ const styles = theme => ({
     width: '100%',
     height: '307px',
     minHeight: '100%',
-    objectFit: 'cover'
+    objectFit: 'cover',
+    [theme.breakpoints.down('xs')]: {
+      height: 185
+    }
   },
   paragraphContainer: {
+    position: 'relative',
     margin: '0px',
     display: 'flex',
     alignItems: 'center',
     width: '100%',
-    minHeight: '307px'
+    minHeight: '307px',
+    [theme.breakpoints.down('xs')]: {
+      minHeight: 185
+    }
   },
   paragraphTypography: {
     fontSize: 16,
@@ -309,8 +320,5 @@ const styles = theme => ({
   }
 });
 export default withStyles(styles)(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(withTranslation()(Achievements))
+  connect(mapStateToProps, mapDispatchToProps)(withTranslation()(Achievements))
 );

--- a/src/screens/lifemap/BeginStoplight.js
+++ b/src/screens/lifemap/BeginStoplight.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
 import { withTranslation } from 'react-i18next';
-import { Typography } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
 import TitleBar from '../../components/TitleBar';
 import beginLifemap from '../../assets/begin_lifemap.png';
 import BottomSpacer from '../../components/BottomSpacer';
@@ -30,8 +30,6 @@ export class Begin extends Component {
       stoplightSkipped: true
     });
     if (this.props.currentSurvey.surveyConfig.pictureSupport) {
-      //TODO Push to Picture
-      console.log('Redirect to pictures view');
       this.props.history.push('/lifemap/upload-pictures');
     } else if (this.props.currentSurvey.surveyConfig.signSupport) {
       this.props.history.push('/lifemap/sign');
@@ -61,7 +59,7 @@ export class Begin extends Component {
           variant="stretch"
           className={classes.BeginStopLightContainer}
         >
-          <Typography variant="h5" className={classes.StopLightTitleContainer}>
+          <Typography variant="h5" className={classes.stopLightTitleContainer}>
             {stoplightOptional
               ? t('views.lifemap.thisLifeMapHasNoStoplight').replace(
                   '%n',
@@ -75,16 +73,9 @@ export class Begin extends Component {
             alt=""
           />
 
-          <div className={classes.buttonContainerForm}>
-            {/* <div style={{ display: 'flex', flex: 1 }}></div> */}
-            <div
-              style={{
-                display: 'flex',
-                flex: 1,
-                justifyContent: 'space-evenly'
-              }}
-            >
-              {stoplightOptional && (
+          <Grid container spacing={2} className={classes.buttonContainerForm}>
+            {stoplightOptional && (
+              <Grid item md={6} xs={12} container justify="center">
                 <Button
                   variant="outlined"
                   color="primary"
@@ -93,7 +84,9 @@ export class Begin extends Component {
                 >
                   {t('general.closeAndSign')}
                 </Button>
-              )}
+              </Grid>
+            )}
+            <Grid item md={6} xs={12} container justify="center">
               <Button
                 variant="contained"
                 color="primary"
@@ -104,8 +97,8 @@ export class Begin extends Component {
                   ? t('general.completeStoplight')
                   : t('general.continue')}
               </Button>
-            </div>
-          </div>
+            </Grid>
+          </Grid>
           <BottomSpacer />
         </Container>
       </div>
@@ -121,10 +114,10 @@ const mapStateToProps = ({ currentSurvey, currentDraft, user }) => ({
 
 const styles = theme => ({
   buttonContainerForm: {
-    display: 'flex',
     marginTop: theme.spacing(4),
     marginBottom: theme.spacing(4),
     justifyContent: 'space-evenly',
+    flex: 1,
     width: '100%'
   },
   BeginStopLightContainer: {
@@ -132,21 +125,33 @@ const styles = theme => ({
     flexDirection: 'column',
     alignItems: 'center'
   },
-  StopLightTitleContainer: {
+  stopLightTitleContainer: {
     width: '50%',
     margin: '50px auto 0 auto',
-    textAlign: 'center'
+    textAlign: 'center',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 18,
+      lineHeight: 1.2
+    }
   },
   beginStopLightImage: {
     marginTop: 40,
     marginBottom: 80,
     position: 'relative',
-    left: -10
+    left: -10,
+    [theme.breakpoints.down('md')]: {
+      width: 400,
+      marginTop: 20,
+      marginBottom: 50
+    },
+    [theme.breakpoints.down('500')]: {
+      width: 300
+    }
   },
   labelGreenRight: {
     marginRight: 20,
     fontSize: 16,
-    color: '#309E43',
+    color: theme.palette.primary.dark,
     paddingLeft: '3rem',
     textAlign: 'right'
   }

--- a/src/screens/lifemap/Final.js
+++ b/src/screens/lifemap/Final.js
@@ -264,7 +264,13 @@ const styles = theme => ({
   beginStopLightImage: {
     marginTop: 40,
     marginBottom: 80,
-    height: '15rem'
+    height: '15rem',
+    [theme.breakpoints.down('md')]: {
+      height: '10rem',
+      width: 400,
+      marginTop: 20,
+      marginBottom: 25
+    }
   },
   imageContainer: {
     display: 'flex',

--- a/src/screens/lifemap/Priority.js
+++ b/src/screens/lifemap/Priority.js
@@ -144,20 +144,20 @@ class Priority extends Component {
                 )}
               </React.Fragment>
             </div>
-            <div className={classes.answeredQuestion}>
-              <i
-                style={{
-                  backgroundColor: color
-                }}
-                className={`material-icons ${classes.icon}`}
-              >
-                done
-              </i>
-            </div>
             <div
               className={classes.paragraphContainer}
               style={{ backgroundColor: color }}
             >
+              <div className={classes.answeredQuestion}>
+                <i
+                  style={{
+                    backgroundColor: color
+                  }}
+                  className={`material-icons ${classes.icon}`}
+                >
+                  done
+                </i>
+              </div>
               <div className={classes.editContainer}>
                 <EditIcon className={classes.editIcon} />
               </div>
@@ -277,9 +277,13 @@ const styles = theme => ({
     alignItems: 'center',
     position: 'absolute',
     top: '50%',
-    left: '50%',
+    left: '0%',
     transform: 'translate(-50%,-50%)',
-    zIndex: 1
+    zIndex: 1,
+    [theme.breakpoints.down('xs')]: {
+      top: '0%',
+      left: '50%'
+    }
   },
   pinAndPriority: {
     marginTop: '40px',
@@ -292,14 +296,21 @@ const styles = theme => ({
     width: '100%',
     height: '307px',
     minHeight: '100%',
-    objectFit: 'cover'
+    objectFit: 'cover',
+    [theme.breakpoints.down('xs')]: {
+      height: 185
+    }
   },
   paragraphContainer: {
+    position: 'relative',
     margin: '0px',
     display: 'flex',
     alignItems: 'center',
     width: '100%',
-    minHeight: '307px'
+    minHeight: '307px',
+    [theme.breakpoints.down('xs')]: {
+      minHeight: 185
+    }
   },
   paragraphTypography: {
     fontSize: 16,

--- a/src/screens/lifemap/SendLifemap.js
+++ b/src/screens/lifemap/SendLifemap.js
@@ -52,7 +52,11 @@ const styles = theme => ({
     marginRight: theme.spacing(4) - 8,
     marginTop: theme.spacing(4)
   },
-  saveButtonStyle: { marginTop: theme.spacing(6) },
+  saveButtonStyle: {
+    height: 'fit-content',
+    minHeight: 38,
+    marginTop: theme.spacing(6)
+  },
   leftIcon: {
     marginRight: theme.spacing(),
     fontSize: 20

--- a/src/screens/lifemap/SendLifemap.js
+++ b/src/screens/lifemap/SendLifemap.js
@@ -25,14 +25,22 @@ const styles = theme => ({
     display: 'flex',
     justifyContent: 'center',
     textAlign: 'center',
-    marginTop: theme.spacing(6)
+    marginTop: theme.spacing(6),
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 18,
+      lineHeight: 1.2
+    }
   },
   chooseOption: {
     display: 'flex',
     justifyContent: 'center',
     textAlign: 'center',
     width: '65%',
-    margin: 'auto'
+    margin: 'auto',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 18,
+      lineHeight: 1.2
+    }
   },
   saveButtonContainer: {
     display: 'flex',
@@ -63,16 +71,6 @@ const styles = theme => ({
   buttonContainer: {
     display: 'flex',
     justifyContent: 'center'
-  },
-  beginStopLightImage: {
-    marginTop: 40,
-    marginBottom: 80,
-    height: '15rem'
-  },
-  imageContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center'
   }
 });
 

--- a/src/screens/lifemap/SkippedIndicator.js
+++ b/src/screens/lifemap/SkippedIndicator.js
@@ -69,7 +69,13 @@ const SkippedIndicator = props => {
 
 const styles = theme => ({
   skippedQuestionsImg: {
-    height: '240px'
+    width: 350,
+    marginTop: 40,
+    marginBottom: 30,
+    alignSelf: 'center',
+    [theme.breakpoints.down('500')]: {
+      width: 285
+    }
   },
   imgContainer: {
     marginTop: theme.spacing(6),

--- a/src/screens/lifemap/SkippedQuestions.js
+++ b/src/screens/lifemap/SkippedQuestions.js
@@ -122,7 +122,10 @@ const styles = theme => ({
     width: 350,
     marginTop: 40,
     marginBottom: 30,
-    alignSelf: 'center'
+    alignSelf: 'center',
+    [theme.breakpoints.down('500')]: {
+      width: 285
+    }
   },
   container: {
     marginTop: 10,

--- a/src/screens/lifemap/StoplightQuestions.js
+++ b/src/screens/lifemap/StoplightQuestions.js
@@ -530,7 +530,8 @@ const styles = theme => ({
     marginBottom: 20
   },
   infoModal: {
-    width: 500,
+    width: '80vw',
+    maxWidth: 500,
     maxHeight: 500,
     backgroundColor: '#fff',
     position: 'absolute',
@@ -541,7 +542,10 @@ const styles = theme => ({
     padding: theme.spacing(6),
     display: 'flex',
     alignItems: 'center',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    [theme.breakpoints.down('xs')]: {
+      padding: theme.spacing(3)
+    }
   },
   closeModalIcon: {
     alignSelf: 'flex-end'
@@ -549,7 +553,9 @@ const styles = theme => ({
   innerContainer: {
     height: '100%',
     width: '100%',
-    overflowY: 'auto'
+    overflowY: 'auto',
+    textAlign: 'justify',
+    paddingRight: 10
   },
   playerContainer: {
     display: 'flex',


### PR DESCRIPTION
What to test:

- Questions options reaction to small screens, normally there would be 3 options per row but in small screen  now only 2 will appear.
- Save as draft modal
- Image of the Begin stoplight view it's now responsive also  the text adjust a little bit.
- Indicator definition modal
- Skip stoplight 
- Add priorities 
- Add achievements 
- Send lifemap ( The last screen after saving a survey where you can send it  through mail or whatsapp)