### PR TITLE
Guillecaba 1521 Add - between words in tooltip operations

### DIFF
--- a/src/components/GreenLineChart.js
+++ b/src/components/GreenLineChart.js
@@ -91,7 +91,9 @@ const GreenLineChart = withTranslation()(
         case 'totalRetakes':
           const retakesList = payload.retakesBySnapNumber
             .map((number, index) => {
-              return `• ${number} N˚${index + 2} ${t('views.survey.followUp')}`;
+              return `• ${number} - N˚${index + 2} ${t(
+                'views.survey.followUp'
+              )}`;
             })
             .join(' \n ');
           tooltipLabel = `${payload[dataKey]} ${t(


### PR DESCRIPTION
#1521 
![image (4)](https://user-images.githubusercontent.com/9329111/107521359-38a99580-6b91-11eb-955d-a44792b228bf.png)

example: 2 - N°2 Follow-up surveys
