### PR TITLE
[details overview] Show economic and family data per snapshot

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1080,7 +1080,7 @@ export const getSnapshotsByFamily = (familyId, user) =>
     },
     data: JSON.stringify({
       query:
-        'query getSnapshotsByFamily($familyId: Long!) { familySnapshotsOverview (familyId: $familyId) { snapshots { snapshotId snapshotDate stoplightSkipped surveyUser projectTitle  stoplight {codeName value shortName lifemapName priority achievement } priorities {indicator} achievements {indicator} } } }',
+        'query getSnapshotsByFamily($familyId: Long!) { familySnapshotsOverview (familyId: $familyId) { snapshots { snapshotId snapshotDate stoplightSkipped surveyUser projectTitle  stoplight {codeName value shortName lifemapName priority achievement } priorities {indicator} achievements {indicator} familyData{ name  familyMembersList { memberIdentifier firstParticipant firstName lastName gender genderText customGender birthDate documentType documentTypeText customDocumentType documentNumber birthCountry email phoneNumber phoneCode socioEconomicAnswers{ key value } } } economic {codeName value multipleValueArray questionText text multipleText multipleTextArray other topic} membersEconomic{ memberIdentifier firstName economic{codeName value multipleValue multipleValueArray questionText text multipleText multipleTextArray other topic} } } } }',
       variables: {
         familyId: familyId
       }

--- a/src/components/DetailsOverview.js
+++ b/src/components/DetailsOverview.js
@@ -29,6 +29,7 @@ import {
   picturesSignaturesBySnapshot
 } from '../api';
 import ImagePreview from './ImagePreview';
+import Details from '../screens/families/profile/Details';
 
 const useStyles = makeStyles(theme => ({
   overviewContainer: {
@@ -46,11 +47,10 @@ const useStyles = makeStyles(theme => ({
     fontSize: 20
   },
   gridContainer: {
-    height: 80,
+    marginBottom: 5,
     backgroundColor: theme.palette.background.default
   },
   buttonsContainer: {
-    height: 80,
     display: 'flex',
     justifyContent: 'space-between'
   },
@@ -156,10 +156,7 @@ const useStyles = makeStyles(theme => ({
     }
   },
   dimensionQuestionsContainer: {
-    marginTop: '30px',
-    [theme.breakpoints.down('xs')]: {
-      marginTop: '150px'
-    }
+    marginTop: '30px'
   },
   buttonLabel: {
     fontWeight: 600,
@@ -189,7 +186,8 @@ const DetailsOverview = ({
   snapshot,
   firstParticipant,
   user,
-  reloadPage
+  reloadPage,
+  survey
 }) => {
   const {
     t,
@@ -341,23 +339,26 @@ const DetailsOverview = ({
   const showButton = (button, { role }, family) => {
     if (button === 'whatsapp') {
       return (
-        role === ROLES_NAMES.ROLE_SURVEY_USER ||
-        role === ROLES_NAMES.ROLE_SURVEY_USER_ADMIN
+        (role === ROLES_NAMES.ROLE_SURVEY_USER ||
+          role === ROLES_NAMES.ROLE_SURVEY_USER_ADMIN) &&
+        !snapshot.stoplightSkipped
       );
     } else if (button === 'email') {
       return (
-        role === ROLES_NAMES.ROLE_SURVEY_USER ||
-        role === ROLES_NAMES.ROLE_SURVEY_USER_ADMIN ||
-        role === ROLES_NAMES.ROLE_APP_ADMIN
+        (role === ROLES_NAMES.ROLE_SURVEY_USER ||
+          role === ROLES_NAMES.ROLE_SURVEY_USER_ADMIN ||
+          role === ROLES_NAMES.ROLE_APP_ADMIN) &&
+        !snapshot.stoplightSkipped
       );
     } else if (button === 'download') {
       return (
-        role === ROLES_NAMES.ROLE_HUB_ADMIN ||
-        role === ROLES_NAMES.ROLE_APP_ADMIN ||
-        role === ROLES_NAMES.ROLE_ROOT ||
-        role === ROLES_NAMES.ROLE_PS_TEAM ||
-        role === ROLES_NAMES.ROLE_SURVEY_USER ||
-        role === ROLES_NAMES.ROLE_SURVEY_USER_ADMIN
+        (role === ROLES_NAMES.ROLE_HUB_ADMIN ||
+          role === ROLES_NAMES.ROLE_APP_ADMIN ||
+          role === ROLES_NAMES.ROLE_ROOT ||
+          role === ROLES_NAMES.ROLE_PS_TEAM ||
+          role === ROLES_NAMES.ROLE_SURVEY_USER ||
+          role === ROLES_NAMES.ROLE_SURVEY_USER_ADMIN) &&
+        !snapshot.stoplightSkipped
       );
     } else if (button === 'delete') {
       return (
@@ -552,6 +553,16 @@ const DetailsOverview = ({
         </Grid>
       </div>
 
+      <Details
+        primaryParticipant={firstParticipant}
+        familyMembers={family.familyMemberDTOList}
+        latitude={family.latitude}
+        longitude={family.longitude}
+        economicData={snapshot.economic}
+        membersEconomicData={snapshot.membersEconomic}
+        survey={survey}
+      />
+
       <div className={classes.overviewContainer}>
         <div className={classes.dimensionQuestionsContainer}>
           <DimensionQuestion
@@ -563,15 +574,20 @@ const DetailsOverview = ({
           />
         </div>
       </div>
-      <FamilyPriorities
-        stoplightSkipped={true}
-        questions={snapshot}
-        priorities={prioritiesList}
-        fullWidth={true}
-        readOnly
-      />
 
-      <FamilyAchievements achievements={achievementsList} fullWidth={true} />
+      {!snapshot.stoplightSkipped && (
+        <FamilyPriorities
+          stoplightSkipped={false}
+          questions={snapshot}
+          priorities={prioritiesList}
+          fullWidth={true}
+          readOnly
+        />
+      )}
+
+      {!snapshot.stoplightSkipped && (
+        <FamilyAchievements achievements={achievementsList} fullWidth={true} />
+      )}
 
       {/* Images */}
       {images.length > 0 && (

--- a/src/components/LifemapDetailsTable.js
+++ b/src/components/LifemapDetailsTable.js
@@ -10,7 +10,7 @@ import IndicatorBall from './summary/IndicatorBall';
 import { theme } from '../theme';
 
 const useStyles = makeStyles(theme => ({
-  familyContainer: {
+  tableContainer: {
     zIndex: 2,
     backgroundColor: theme.palette.background.default,
     display: 'flex',
@@ -188,13 +188,13 @@ const LifemapDetailsTable = ({
     return columns;
   };
   return (
-    <div className={classes.familyContainer}>
+    <div className={classes.tableContainer}>
       <MaterialTable
         tableRef={tableRef}
         options={{
           search: false,
           toolbar: false,
-          pageSize: numberOfRows,
+          pageSize: numberOfRows > 0 ? numberOfRows : 10,
           pageSizeOptions: [],
           draggable: false,
           rowStyle: rowData => ({

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -536,7 +536,7 @@
       "profile": "Profile",
       "createNewSnapshot": "Create a new survey for the family!",
       "stoplight": "Stoplight",
-      "loadingSnapshots": "Loading stoplights...",
+      "loadingSnapshots": "This family has no stoplights...",
       "familyNoteSuccess": "Family note sent correctly",
       "familyNoteError": "Could not send family note",
       "download": "Download",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -536,7 +536,7 @@
       "profile": "Perfil",
       "createNewSnapshot": "¡Crea una nueva encuesta para la familia!",
       "stoplight": "Semáforo",
-      "loadingSnapshots": "Cargando semáforos...",
+      "loadingSnapshots": "Esta familia no tiene semáforos ...",
       "familyNoteSuccess": "Nota de familia enviada correctamente",
       "familyNoteError": "No se pudo enviar la nota familiar",
       "download": "Descargar",

--- a/src/locales/ht.json
+++ b/src/locales/ht.json
@@ -539,7 +539,7 @@
       "profile": "Pwofil",
       "createNewSnapshot": "Kreye yon nouvo ankèt pou fanmi an.",
       "stoplight": "Chimen Pwogrè",
-      "loadingSnapshots": "Chimen pwogrè ap chaje..",
+      "loadingSnapshots": "Fanmi sa a pa gen okenn stoplights ...",
       "familyNoteSuccess": "Nòt sou fanmi an ale korekteman",
       "familyNoteError": "Nou pa t ka voye nòt sou fanmi an ale.",
       "download": "Telechaje",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -535,7 +535,7 @@
       "profile": "Perfil",
       "createNewSnapshot": "Crie um nova pesquisa às famílias!",
       "stoplight": "Semáforo",
-      "loadingSnapshots": "Carregando semáforos...",
+      "loadingSnapshots": "Esta família não tem semáforos ...",
       "familyNoteSuccess": "Nota de família enviada corretamente",
       "familyNoteError": "Não foi possível enviar o bilhete da família",
       "download": "Baixar",

--- a/src/screens/families/profile/FamilyOverview.js
+++ b/src/screens/families/profile/FamilyOverview.js
@@ -264,13 +264,11 @@ const FamilyOverview = ({
           draft={family.snapshotIndicators ? family.snapshotIndicators : null}
         />
 
-        {!stoplightSkipped && (
-          <Typography variant="subtitle1" className={classes.labelGreenRight}>
-            <Link onClick={goToFamilyDetails} style={{ cursor: 'pointer' }}>
-              {t('views.familyProfile.viewLifeMap')}
-            </Link>
-          </Typography>
-        )}
+        <Typography variant="subtitle1" className={classes.labelGreenRight}>
+          <Link onClick={goToFamilyDetails} style={{ cursor: 'pointer' }}>
+            {t('views.familyProfile.viewLifeMap')}
+          </Link>
+        </Typography>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
You'll find backend support in this PR https://github.com/FundacionParaguaya/stoplight-server/pull/2195

From now on  Snapshot's details view should be always visible  even if the family has just one snapshot  without it's stoplight section